### PR TITLE
DCWL-2110: disable ssl port due to issues with play since java17

### DIFF
--- a/test/util/ItSpec.scala
+++ b/test/util/ItSpec.scala
@@ -80,7 +80,7 @@ trait ItSpec
 
   object TestServerFactory extends DefaultTestServerFactory {
     override protected def serverConfig(app: Application): ServerConfig = {
-      val sc = ServerConfig(port    = Some(testServerPort), sslPort = Some(0), mode = Mode.Test, rootDir = app.path)
+      val sc = ServerConfig(port    = Some(testServerPort), sslPort = None, mode = Mode.Test, rootDir = app.path)
       sc.copy(configuration = sc.configuration.withFallback(overrideServerConfiguration(app)))
     }
   }


### PR DESCRIPTION
Please ensure we are following our Ways of Working for Pull Requests: https://confluence.tools.tax.service.gov.uk/display/BTL/Ways+of+Working+for+Pull+Requests